### PR TITLE
Add React Native port

### DIFF
--- a/react_native/README.md
+++ b/react_native/README.md
@@ -1,0 +1,9 @@
+# React Native In App Review
+
+This directory contains a TypeScript implementation of an In-App Review module for React Native applications. The API mirrors the original Flutter plugin and exposes three functions:
+
+- `isAvailable()` – checks whether the native in-app review functionality can be used.
+- `requestReview()` – attempts to display the in-app review dialog.
+- `openStoreListing()` – opens the platform's store listing for the application.
+
+Each function delegates to a native module called `InAppReviewModule`. Native implementations for Android and iOS are required.

--- a/react_native/android/src/main/java/com/inappreview/InAppReviewModule.java
+++ b/react_native/android/src/main/java/com/inappreview/InAppReviewModule.java
@@ -1,0 +1,75 @@
+package com.inappreview;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.google.android.play.core.review.ReviewInfo;
+import com.google.android.play.core.review.ReviewManager;
+import com.google.android.play.core.review.ReviewManagerFactory;
+import com.google.android.play.core.tasks.Task;
+
+public class InAppReviewModule extends ReactContextBaseJavaModule {
+    private ReviewInfo reviewInfo;
+    private final ReviewManager manager;
+
+    public InAppReviewModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        manager = ReviewManagerFactory.create(reactContext);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "InAppReviewModule";
+    }
+
+    @ReactMethod
+    public void isAvailable(Promise promise) {
+        promise.resolve(true);
+    }
+
+    @ReactMethod
+    public void requestReview(Promise promise) {
+        Activity activity = getCurrentActivity();
+        if (activity == null) {
+            promise.reject("error", "Activity not available");
+            return;
+        }
+        if (reviewInfo != null) {
+            manager.launchReviewFlow(activity, reviewInfo)
+                    .addOnCompleteListener(task -> promise.resolve(null));
+            return;
+        }
+        Task<ReviewInfo> request = manager.requestReviewFlow();
+        request.addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                reviewInfo = task.getResult();
+                manager.launchReviewFlow(activity, reviewInfo)
+                        .addOnCompleteListener(t -> promise.resolve(null));
+            } else {
+                promise.reject("error", "In-App Review API unavailable");
+            }
+        });
+    }
+
+    @ReactMethod
+    public void openStoreListing(Promise promise) {
+        Activity activity = getCurrentActivity();
+        if (activity == null) {
+            promise.reject("error", "Activity not available");
+            return;
+        }
+        String packageName = activity.getPackageName();
+        Intent intent = new Intent(Intent.ACTION_VIEW,
+                Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
+        activity.startActivity(intent);
+        promise.resolve(null);
+    }
+}

--- a/react_native/android/src/main/java/com/inappreview/InAppReviewPackage.java
+++ b/react_native/android/src/main/java/com/inappreview/InAppReviewPackage.java
@@ -1,0 +1,24 @@
+package com.inappreview;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class InAppReviewPackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new InAppReviewModule(reactContext));
+        return modules;
+    }
+}

--- a/react_native/dist/index.d.ts
+++ b/react_native/dist/index.d.ts
@@ -1,0 +1,13 @@
+export interface OpenStoreOptions {
+    appStoreId?: string;
+    microsoftStoreId?: string;
+}
+export declare function isAvailable(): Promise<boolean>;
+export declare function requestReview(): Promise<void>;
+export declare function openStoreListing(options?: OpenStoreOptions): Promise<void>;
+declare const _default: {
+    isAvailable: typeof isAvailable;
+    requestReview: typeof requestReview;
+    openStoreListing: typeof openStoreListing;
+};
+export default _default;

--- a/react_native/dist/index.js
+++ b/react_native/dist/index.js
@@ -1,0 +1,85 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isAvailable = isAvailable;
+exports.requestReview = requestReview;
+exports.openStoreListing = openStoreListing;
+var react_native_1 = require("react-native");
+var MODULE_NAME = 'InAppReviewModule';
+var InAppReviewModule = react_native_1.NativeModules[MODULE_NAME];
+function ensureAvailable() {
+    if (!InAppReviewModule) {
+        throw new Error("Native module '".concat(MODULE_NAME, "' is not linked"));
+    }
+}
+function isAvailable() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            ensureAvailable();
+            return [2 /*return*/, InAppReviewModule.isAvailable()];
+        });
+    });
+}
+function requestReview() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            ensureAvailable();
+            return [2 /*return*/, InAppReviewModule.requestReview()];
+        });
+    });
+}
+function openStoreListing() {
+    return __awaiter(this, arguments, void 0, function (options) {
+        if (options === void 0) { options = {}; }
+        return __generator(this, function (_a) {
+            ensureAvailable();
+            if (react_native_1.Platform.OS === 'ios' && !options.appStoreId) {
+                throw new Error('appStoreId is required on iOS');
+            }
+            if (react_native_1.Platform.OS === 'windows' && !options.microsoftStoreId) {
+                throw new Error('microsoftStoreId is required on Windows');
+            }
+            return [2 /*return*/, InAppReviewModule.openStoreListing(options)];
+        });
+    });
+}
+exports.default = {
+    isAvailable: isAvailable,
+    requestReview: requestReview,
+    openStoreListing: openStoreListing,
+};

--- a/react_native/ios/InAppReviewModule.mm
+++ b/react_native/ios/InAppReviewModule.mm
@@ -1,0 +1,44 @@
+#import <React/RCTBridgeModule.h>
+#import <StoreKit/StoreKit.h>
+
+@interface InAppReviewModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation InAppReviewModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  if (@available(iOS 10.3, *)) {
+    resolve(@(YES));
+  } else {
+    resolve(@(NO));
+  }
+}
+
+RCT_EXPORT_METHOD(requestReview:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  if (@available(iOS 10.3, *)) {
+    [SKStoreReviewController requestReview];
+  }
+  resolve(nil);
+}
+
+RCT_EXPORT_METHOD(openStoreListing:(NSDictionary *)options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *appStoreId = options[@"appStoreId"];
+  if (appStoreId == nil) {
+    reject(@"error", @"appStoreId is required on iOS", nil);
+    return;
+  }
+  NSString *urlString = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/id%@?action=write-review", appStoreId];
+  [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString] options:@{} completionHandler:nil];
+  resolve(nil);
+}
+
+@end

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native-in-app-review",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/react_native/src/index.ts
+++ b/react_native/src/index.ts
@@ -1,0 +1,46 @@
+import { NativeModules, Platform } from 'react-native';
+
+export interface OpenStoreOptions {
+  appStoreId?: string;
+  microsoftStoreId?: string;
+}
+
+const MODULE_NAME = 'InAppReviewModule';
+const InAppReviewModule = NativeModules[MODULE_NAME] as {
+  isAvailable: () => Promise<boolean>;
+  requestReview: () => Promise<void>;
+  openStoreListing: (options: OpenStoreOptions) => Promise<void>;
+};
+
+function ensureAvailable() {
+  if (!InAppReviewModule) {
+    throw new Error(`Native module '${MODULE_NAME}' is not linked`);
+  }
+}
+
+export async function isAvailable(): Promise<boolean> {
+  ensureAvailable();
+  return InAppReviewModule.isAvailable();
+}
+
+export async function requestReview(): Promise<void> {
+  ensureAvailable();
+  return InAppReviewModule.requestReview();
+}
+
+export async function openStoreListing(options: OpenStoreOptions = {}): Promise<void> {
+  ensureAvailable();
+  if (Platform.OS === 'ios' && !options.appStoreId) {
+    throw new Error('appStoreId is required on iOS');
+  }
+  if (Platform.OS === 'windows' && !options.microsoftStoreId) {
+    throw new Error('microsoftStoreId is required on Windows');
+  }
+  return InAppReviewModule.openStoreListing(options);
+}
+
+export default {
+  isAvailable,
+  requestReview,
+  openStoreListing,
+};

--- a/react_native/tsconfig.json
+++ b/react_native/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es6"],
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src", "typings"]
+}

--- a/react_native/typings/react-native.d.ts
+++ b/react_native/typings/react-native.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-native' {
+  export const NativeModules: any;
+  export const Platform: {
+    OS: string;
+  };
+}


### PR DESCRIPTION
## Summary
- add a new `react_native` directory with a TypeScript implementation of the in-app review API
- include minimal native modules for Android and iOS

## Testing
- `npx tsc`