### PR TITLE
Add iOS podspec for React Native

### DIFF
--- a/react_native/ios/ReactNativeInAppReview.podspec
+++ b/react_native/ios/ReactNativeInAppReview.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = 'ReactNativeInAppReview'
+  s.version      = '0.1.0'
+  s.summary      = 'In-app review support for React Native.'
+  s.homepage     = 'https://github.com/britannio/in_app_review'
+  s.license      = { :type => 'MIT' }
+  s.author       = { 'Britannio Jarrett' => 'britanniojarrett@gmail.com' }
+  s.platform     = :ios, '12.0'
+  s.source       = { :path => '.' }
+  s.source_files = 'InAppReviewModule.mm'
+  s.requires_arc = true
+  s.dependency 'React-Core'
+end

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "src"],
+  "files": ["dist", "src", "ios"],
   "scripts": {
     "build": "tsc"
+  },
+  "react-native": {
+    "podspecPath": "ios/ReactNativeInAppReview.podspec"
   }
 }


### PR DESCRIPTION
## Summary
- add ReactNativeInAppReview.podspec pointing to `InAppReviewModule.mm`
- reference the podspec in `package.json`

## Testing
- `npm run build`