### PR TITLE
Add Gradle build script for RN Android module

### DIFF
--- a/react_native/android/build.gradle
+++ b/react_native/android/build.gradle
@@ -1,0 +1,37 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.facebook.react:react-native-gradle-plugin'
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'com.facebook.react'
+
+android {
+    namespace 'com.inappreview'
+    compileSdkVersion 33
+
+    defaultConfig {
+        minSdkVersion 16
+    }
+
+    // Ensure Java source files under src/main/java are included
+    sourceSets {
+        main.java.srcDirs += 'src/main/java'
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-native'
+    implementation 'com.google.android.play:review:2.0.2'
+}


### PR DESCRIPTION
## Summary
- add `react_native/android/build.gradle` for building the React Native native module

## Testing
- `gradle tasks --all --no-daemon --console=plain` *(fails: Could not resolve dependencies - no network)*