### PR TITLE
Add root package.json for React Native workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "workspaces": ["react_native"]
+}


### PR DESCRIPTION
## Summary
- add `package.json` at repository root to mark the repo as private and define the `react_native` workspace

## Testing
- `flutter --version` *(fails: command not found)*