### PR TITLE
Install @types/react-native and cleanup

### DIFF
--- a/react_native/package.json
+++ b/react_native/package.json
@@ -4,10 +4,17 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "podspecPath": "ios/ReactNativeInAppReview.podspec",
-  "files": ["dist", "ios", "android"],
+  "files": [
+    "dist",
+    "ios",
+    "android"
+  ],
   "scripts": {
     "build": "tsc",
     "postinstall": "tsc",
     "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/react-native": "*"
   }
 }

--- a/react_native/tsconfig.json
+++ b/react_native/tsconfig.json
@@ -2,11 +2,18 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es6"],
+    "lib": [
+      "es6"
+    ],
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": [
+      "react-native"
+    ]
   },
-  "include": ["src", "typings"]
+  "include": [
+    "src"
+  ]
 }

--- a/react_native/typings/react-native.d.ts
+++ b/react_native/typings/react-native.d.ts
@@ -1,6 +1,0 @@
-declare module 'react-native' {
-  export const NativeModules: any;
-  export const Platform: {
-    OS: string;
-  };
-}


### PR DESCRIPTION
## Summary
- install `@types/react-native` as a dev dependency for the React Native module
- remove the local `typings/react-native.d.ts`
- tell TypeScript to use `react-native` types from `node_modules`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'react-native')*