### PR TITLE
Add React Native Android gradle configuration

### DIFF
--- a/react_native/android/build.gradle
+++ b/react_native/android/build.gradle
@@ -23,7 +23,7 @@ android {
     // Include the React Native module sources located at
     // android/src/main/java/com/inappreview
     sourceSets {
-        main.java.srcDirs += 'src/main/java'
+        main.java.srcDirs += 'src/main/java/com/inappreview'
     }
 }
 

--- a/react_native/android/settings.gradle
+++ b/react_native/android/settings.gradle
@@ -1,1 +1,2 @@
+// Settings for the React Native library module
 rootProject.name = 'react-native-in-app-review'


### PR DESCRIPTION
## Summary
- update Gradle source path for android library
- add a comment to Android settings.gradle

## Testing
- `npm run build` in `react_native`
- `gradle build` *(fails: Could not resolve dependencies due to no network)*