### PR TITLE
Install react-native types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@types/react-native": "*"
+    "@types/react-native": "^0.72.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "esModuleInterop": true,
-    "types": [
-      "react-native"
-    ]
+    "esModuleInterop": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary
- use `@types/react-native` dev dependency
- rely on the default type resolution from `node_modules`

## Testing
- `npm run build` *(fails: Cannot find module 'react-native' or its corresponding type declarations)*
- `npm install` *(fails: network access needed)*