### PR TITLE
Add react_native Android module

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,6 @@
 // Settings for the React Native library module
 rootProject.name = 'react-native-in-app-review'
+
+// Include the support library used by this repository
+include ':react_native'
+project(':react_native').projectDir = new File(settingsDir, '../react_native/android')

--- a/react_native/android/build.gradle
+++ b/react_native/android/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 33
+    defaultConfig { minSdkVersion 21 }
+}
+
+dependencies {
+    implementation "com.google.android.play:review:2.0.2"
+    implementation "com.google.android.gms:play-services-base:18.2.0"
+}


### PR DESCRIPTION
## Summary
- add Gradle build script for a new react_native Android library
- include the module in the existing settings.gradle so Android tooling can find it

## Testing
- `npm run build` *(fails: Cannot find module 'react-native')*