### PR TITLE
Fix podspec source file and privacy bundle path

### DIFF
--- a/ReactNativeInAppReview.podspec
+++ b/ReactNativeInAppReview.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.version          = '0.1.0'
   s.summary          = 'React Native plugin for showing the In-App Review/System Rating pop up.'
   s.source           = { :path => '.' }
-  s.source_files     = 'ios/Sources/**/*'
+  s.source_files     = 'ios/Sources/*.{h,m,mm}'
   s.platform         = :ios, '12.0'
   s.requires_arc     = true
   s.license          = package["license"]
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.resource_bundles = {'in_app_review_privacy' => ['Sources/PrivacyInfo.xcprivacy']}
+  s.resource_bundles = { 'in_app_review_privacy' => ['ios/Sources/PrivacyInfo.xcprivacy'] }
 end


### PR DESCRIPTION
## Summary
- only include Objective-C++ sources for iOS build
- fix path for privacy info bundle in Podspec

## Testing
- `pod install` *(fails: `pod` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ec01f3f908322951c39683896ee81